### PR TITLE
fix: match engagement response types to actual API response

### DIFF
--- a/src/resources/data/engagement/engagement.ts
+++ b/src/resources/data/engagement/engagement.ts
@@ -34,25 +34,25 @@ export class Engagement extends APIResource {
 
 export interface EngagementHeatmap {
   /**
-   * Total number of views the heatmap was calculated from.
+   * The asset ID this data is for.
    */
-  total_views: number;
+  asset_id: string;
 
   /**
    * Per-bucket engagement values across the content timeline, ordered from the start
    * to the end of the content. The number of buckets is dynamic (between 10
    * and 1000) and scales with the content duration.
    */
-  value: Array<number>;
+  heatmap: Array<number>;
 }
 
 export interface EngagementHotspots {
-  hotspots: Array<Hotspot>;
-
   /**
-   * Total number of views the hotspots were calculated from.
+   * The asset ID this data is for.
    */
-  total_views: number;
+  asset_id: string;
+
+  hotspots: Array<Hotspot>;
 }
 
 export interface Hotspot {


### PR DESCRIPTION
## Summary

Fix #638 - Engagement response types don't match the live API response shape

The declared TypeScript types for the Data engagement endpoints do not match the response shape the live API returns. Typed consumers reading `data.heatmap` or `data.asset_id` get `undefined` at runtime despite non-optional type declarations.

## Changes

- Renamed `EngagementHeatmap.value` to `EngagementHeatmap.heatmap` to match actual API response
- Added `asset_id` field to both `EngagementHeatmap` and `EngagementHotspots` interfaces
- Removed `total_views` from both interfaces as it's not present in actual API responses

## Actual API Response Format

```json
{
  "total_row_count": null,
  "timeframe": [1780531780, 1788307780],
  "data": {
    "asset_id": "...",
    "heatmap": [0, 0, 0, ...]
  }
}
```

## Breaking Changes

This is a **breaking change** for users who were relying on the incorrect type names (`value` instead of `heatmap`). Users will need to update their code to use the correct property names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript shape changes for engagement analytics consumers, but limited to type definitions with no runtime SDK logic changes.
> 
> **Overview**
> Aligns **`EngagementHeatmap`** and **`EngagementHotspots`** with the live Data engagement API so typed access matches runtime JSON.
> 
> **`EngagementHeatmap`** now exposes **`asset_id`** and renames the timeline buckets from **`value`** to **`heatmap`**, and drops **`total_views`**, which the API does not return. **`EngagementHotspots`** gains **`asset_id`** and also removes **`total_views`**; **`hotspots`** is unchanged aside from field ordering in the type definition.
> 
> This is a **breaking** change for code that used the old names (`value`, `total_views`); consumers should read **`data.asset_id`** and **`data.heatmap`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cd91bbd4058050f764305004ae14bb758e7dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->